### PR TITLE
fix: s/PROXY_IMAGES/MEDIA_PROXY_MODE/

### DIFF
--- a/templates/miniflux.conf.j2
+++ b/templates/miniflux.conf.j2
@@ -84,5 +84,5 @@ OAUTH2_OIDC_DISCOVERY_ENDPOINT={{ miniflux_oauth2_oidc_discovery_endpoint }}
 POCKET_CONSUMER_KEY={{ miniflux_pocket_consumer_key }}
 {%endif%}
 {%if miniflux_proxy_images%}
-PROXY_IMAGES={{ miniflux_proxy_images }}
+MEDIA_PROXY_MODE={{ miniflux_proxy_images }}
 {%endif%}


### PR DESCRIPTION
PROXY_IMAGES not valid anymore
https://github.com/miniflux/v2/blob/main/internal/config/parser.go#L165